### PR TITLE
ReaderHighlight: Highlight menu, change 'Delete' to Trash can icon

### DIFF
--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -1229,7 +1229,7 @@ function ReaderHighlight:onShowHighlightDialog(index)
     local buttons = {
         {
             {
-                text = _("Delete"),
+                text = ("\u{F48E}"), -- Trash can (icon to prevent confusion of Delete/Details buttons)
                 callback = function()
                     self:deleteHighlight(index)
                     UIManager:close(self.edit_highlight_dialog)


### PR DESCRIPTION
Closes #12754; as discussed there.

Other icons or text labels would also be okay, this is only to prevent user confusion of the easily mixed up Details/Delete buttons.
